### PR TITLE
Switches to dynamic light/dark logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-![logo](https://raw.githubusercontent.com/gchq/ConcourseTools/main/docs/source/_static/logo.png)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="./docs/source/_static/logo-dark.png">
+  <source media="(prefers-color-scheme: light)" srcset="./docs/source/_static/logo.png">
+  <img alt="ConcourseTools logo" src="./docs/source/_static/logo.png">
+</picture>
 
 ![version](https://img.shields.io/badge/version-0.7.1-informational)
 ![pre-release](https://img.shields.io/badge/pre--release-beta-red)


### PR DESCRIPTION
Current logo (dark mode):

<img width="693" alt="image" src="https://github.com/phil-ncsc/ConcourseTools/assets/52707208/ea8849f0-3a2c-4f83-bb62-5333a6679b36">

Updated logo (dark mode):

<img width="688" alt="image" src="https://github.com/phil-ncsc/ConcourseTools/assets/52707208/adf329eb-23fe-41ec-9b1a-0c12a408be99">

Updated logo (light mode):

<img width="694" alt="image" src="https://github.com/phil-ncsc/ConcourseTools/assets/52707208/664f9ce1-6e1d-4722-8b42-4db8e11b7505">

Ref: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to
